### PR TITLE
docs: reformat README.md; grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
 # Citer
 
-A citation generator tool for Wikipedia. Currently accessible from:
-http://citer.toolforge.org/ (the English version)
+A citation generator tool for Wikipedia. Currently accessible from:\
+http://citer.toolforge.org/ (the English version)\
 http://yadfa.toolforge.org/ (the Persian version)
 
 ## What does it do?
 
-Citer is specially useful for generating citations from Google Books URLs, DOIs (Any Digital object Identifiers) and ISBNs (International Standard Book Numbers).
-Additionally URL of many major news websites are supported, including:
-The New York Times, BBC, Daily Mail, Daily Mirror, The Daily Telegraph, The Huffington Post, The Washington Post, The Boston Globe, Bloomberg Businessweek, Financial Times, and The Times of India. Special support for the URLs of the [Wayback Machine](https://en.wikipedia.org/wiki/Wayback_Machine) is also implemented.
+Citer is especially useful for generating citations from Google Books URLs, DOIs (Any Digital object Identifiers) and ISBNs (International Standard Book Numbers).
+Additionally, URLs of many major news websites are supported, including:
+
+* The New York Times
+* BBC
+* Daily Mail
+* Daily Mirror
+* The Daily Telegraph
+* The Huffington Post
+* The Washington Post
+* The Boston Globe
+* Bloomberg Businessweek
+* Financial Times
+* The Times of India
+
+Special support for the URLs of the [Wayback Machine](https://en.wikipedia.org/wiki/Wayback_Machine) is also implemented.
 
 Some other tested and supported Persian web-sites:
 * http://www.noormags.ir (نورمگز)
@@ -28,9 +41,8 @@ To run Citer on your local computer:
 5. Copy `config.py.example` to `config.py`. (You might want to get an NCBI API key and add it to the config file if you're going to use its services.)
 4. Run `python3 app.py`.
 
-If everything goes fine, the main page will be accessible from:
+If everything goes fine, the main page will be accessible from:\
     http://localhost:5000/
 
-
 ## Language Setting
-The default language is English and can be change to Persian using the setting in config.py file.
+The default language is English and can be changed to Persian using the setting in the config.py file.


### PR DESCRIPTION
The '\' characters I added causes a line break:

![image](https://user-images.githubusercontent.com/16764864/103049844-7ce8c400-4558-11eb-92dc-0fff4d431cae.png)
