### PR TITLE
remove flup6 from requirements; update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,19 @@ Some other tested and supported Persian web-sites:
 
 To run Citer on your local computer:
 
-1. Install Python 3.7+.
-2. Clone the project.
-3. Install the dependencies using `pip install -r requirements.txt`.
-3. Make sure that `flup` is __not__ installed in your environment.
-5. Copy `config.py.example` to `config.py`. (You might want to get an NCBI API key and add it to the config file if you're going to use its services.)
-4. Run `python3 app.py`.
+1. Install Python 3.7+
+2. Clone the project
+3. Install the dependencies using `pip install --user -r requirements.txt`
+4. Copy `config.py.example` to `config.py` (You might want to get an NCBI API key and add it to the config file if you're going to use its services)
+5. Run `python3 app.py`
 
-If everything goes fine, the main page will be accessible from:\
+If you see html output to your console, this probably means you have
+flup installed. You'll need to uninstall it for Citer to run.
+
+If there are no warnings or error messages (and no html is displayed), the main page will be accessible from:\
     http://localhost:5000/
+
+If you experience any problems or have questions, please open a ticket on this repo.
 
 ## Language Setting
 The default language is English and can be changed to Persian using the setting in the config.py file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-flup6
 isbnlib
 jdatetime
 langid


### PR DESCRIPTION
* remove periods (I don't think these are necessary when using the short
sentences that are a list of instructions)
* remove flup6 from requirements.txt and only mention on the README that
it may need to be installed if html is output

I suggested the '--user' option for installation because this program does not need to be run as root. And I think anyone who normally runs things as root would know to simply not use the suggestion of '--user' when installing if they don't want to.

(fixes #19)