### PR TITLE
Support parameter delimiter spacing options

### DIFF
--- a/lib/commons.py
+++ b/lib/commons.py
@@ -188,7 +188,7 @@ def request(
     return mortal_session().request(method, url, headers=headers, **kwargs)
 
 
-def data_to_sfn_cit_ref(d: dict, date_format: str = '%Y-%m-%d', /) -> tuple:
+def data_to_sfn_cit_ref(d: dict, date_format: str = '%Y-%m-%d', pipe_format: str = ' | ', /) -> tuple:
     # Return (sfn, cite, ref) strings.
     get = d.get
     if title := get('title'):
@@ -201,7 +201,7 @@ def data_to_sfn_cit_ref(d: dict, date_format: str = '%Y-%m-%d', /) -> tuple:
             # https://github.com/CrossRef/rest-api-doc/issues/214
             del d['isbn']
 
-    return sfn_cit_ref(d, date_format)
+    return sfn_cit_ref(d, date_format, pipe_format)
 
 
 def first_last(fullname, separator=None) -> tuple:

--- a/lib/generator_fa.py
+++ b/lib/generator_fa.py
@@ -26,7 +26,7 @@ CITE_TYPE_TO_PERSIAN = {
 DIGITS_TO_FA = str.maketrans('0123456789', '۰۱۲۳۴۵۶۷۸۹')
 
 
-def sfn_cit_ref(d: dict[str, Any], _: str = '%Y-%m-%d', /) -> tuple:
+def sfn_cit_ref(d: dict[str, Any], _: str = '%Y-%m-%d', pipe: str = ' | ', /) -> tuple:
     """Return sfn, citation, and ref."""
     g = d.get
     if not (cite_type := type_to_cite(g('cite_type'))):

--- a/lib/html/__init__.py
+++ b/lib/html/__init__.py
@@ -55,7 +55,7 @@ HTML_SUBST = Template(
 ).substitute
 
 
-def scr_to_html(scr: tuple, date_format: str, input_type: str):
+def scr_to_html(scr: tuple, date_format: str, pipe_format: str, input_type: str):
     """Insert sfn_cit_ref into the HTML template and return response_body."""
     sfn, cit, ref = [escape(i) for i in scr]
     return (
@@ -65,6 +65,7 @@ def scr_to_html(scr: tuple, date_format: str, input_type: str):
             ref=ref,
         )
         .replace(f'{date_format}"', f'{date_format}" checked', 1)
+        .replace(f'{pipe_format}"', f'{pipe_format}" checked', 1)
         .replace(f'="{input_type}"', f'="{input_type}" selected', 1)
     )
 

--- a/lib/html/en.html
+++ b/lib/html/en.html
@@ -24,6 +24,11 @@
 			<input type="radio" name="dateformat" value="%b %{d}, %Y" id="bdy" onclick="onDateChange()">Jan 1, 2020
 			<input type="radio" name="dateformat" value="%{d} %B %Y" id="dbby" onclick="onDateChange()">1 January 2020
 			<input type="radio" name="dateformat" value="%{d} %b %Y" id="dby" onclick="onDateChange()">1 Jan 2020
+			<br>
+			<p class="input-legend">Pipe spacing:</p>
+			<input type="radio" name="pipeformat" value=" | " id="both" onclick="onPipeChange()">{{cite book | last=Smith | first=Bob}}
+			<input type="radio" name="pipeformat" value=" |" id="before" onclick="onPipeChange()">{{cite book |last=Smith |first=Bob}}
+			<input type="radio" name="pipeformat" value="|" id="none" onclick="onPipeChange()">{{cite book|last=Smith|first=Bob}}
 			<br><br>
 		</form>
 		<a href="https://en.wikipedia.org/wiki/Help:Shortened_footnotes">Shortened footnote</a> and citation:
@@ -50,7 +55,7 @@
 			</p>
 			<p>
 				Found a bug or have a suggestion? Contact me on <a href="https://meta.wikimedia.org/wiki/User_talk:Dalba">my talk page</a> or open an issue <a href="https://github.com/5j9/citer">on GitHub</a>.
-				<a id="bookmarklet" href="javascript:void(window.open('https://citer.toolforge.org/?user_input='+encodeURIComponent(location.href)+'&dateformat='+encodeURIComponent('%B %{d}, %Y')))">Bookmarklet (drag to favorites bar)</a>
+				<a id="bookmarklet" href="javascript:void(window.open('https://citer.toolforge.org/?user_input='+encodeURIComponent(location.href)+'&pipeformat=+|+&dateformat='+encodeURIComponent('%B %{d}, %Y')))">Bookmarklet (drag to favorites bar)</a>
 			</p>
 		</footer>
 		<script src="static/en.js"></script>

--- a/lib/html/en.js
+++ b/lib/html/en.js
@@ -16,11 +16,14 @@ var longMonths = [
 var shortMonths = longMonths.map((s) => s.slice(0, 3));
 var monthPattern = '(' + shortMonths.join('|') + '|' + longMonths.join('|') + ')';
 
-
-function getCheckedRadio() {
+/**
+ *
+ * @param {String} inputname
+ */
+function getCheckedRadio(inputname) {
 	'use strict';
 	var /**@type {any} */radio_group, i, /** @type {HTMLInputElement} */ button;
-	radio_group = document.getElementsByName('dateformat');
+	radio_group = document.getElementsByName(inputname);
 	for (i = 0; i < radio_group.length; i = i + 1) {
 		button = radio_group[i];
 		if (button.checked) {
@@ -116,10 +119,12 @@ function parseDate(s) {
  */
 function changeDates(id) {
 	'use strict';
-	var i, text1, text2, dates, date, newdate, formatter;
+	var i, text1, text2, dates, date, newdate, formatter, pipe;
+	pipe = getCheckedRadio('pipeformat').value;
+
 	text1 = /**@type {HTMLElement} */(document.getElementById('shortened')).innerHTML;
 	text2 = /**@type {HTMLElement} */(document.getElementById('named_ref')).innerHTML;
-	dates = text1.match(/date=.*?(?=\}\}| \| )/g);
+	dates = text1.match(/date=.*?(?=\}\}|\s?\|\s?)/g);
 	if (!dates) return;
 	for (i = 0; i < dates.length; i = i + 1) {
 		date = dates[i].slice(5);  // omit the `date=` part
@@ -130,20 +135,83 @@ function changeDates(id) {
 			continue;
 		}
 		newdate = formatter(...ymd);
-		text1 = text1.replace(new RegExp('((?:access)?date=)' + date + '(?=}}| \\| )'), '$1' + newdate);
-		text2 = text2.replace(new RegExp('((?:access)?date=)' + date + '(?=}}| \\| )'), '$1' + newdate);
+		text1 = text1.replace(new RegExp('((?:access)?date=)' + date + '(?=}}|' + pipe + ')'), '$1' + newdate);
+		text2 = text2.replace(new RegExp('((?:access)?date=)' + date + '(?=}}|' + pipe + ')'), '$1' + newdate);
 		/**@type {HTMLElement} */(document.getElementById('shortened')).innerHTML = text1;
 		/**@type {HTMLElement} */(document.getElementById('named_ref')).innerHTML = text2;
 	}
 }
 
-
-function applyLSDateFormat() {
+function onDateChange() {
 	'use strict';
+	var checkedDate = getCheckedRadio('dateformat');
+	var dateId = checkedDate.id;
+	changeDates(dateId);
+	localStorage.setItem("datefmt", dateId);
+	updateURL('dateformat', checkedDate.value);
+}
+
+/**
+ *
+ * @param {String} id
+ */
+function changePipes(id) {
+	'use strict';
+	var text1, text2, sfns, newpipe;
+
+    newpipe = '|';
+    if (id == 'before') {
+        newpipe = ' |';
+    } else if (id == 'both') {
+        newpipe = ' | ';
+    }
+
+	text1 = /**@type {HTMLElement} */(document.getElementById('shortened')).innerHTML;
+	text2 = /**@type {HTMLElement} */(document.getElementById('named_ref')).innerHTML;
+
+	sfns = text1.match(/\{\{sfn[ref]?.*?(?=\}\})/g);
+
+	if (!sfns) return;
+
+	// temporarily remove sfns which should always be compact
+	text1 = text1.replace(sfns[0], '');
+	text1 = text1.replace(sfns[1], '');
+
+    // replace pipes
+    text1 = text1.replaceAll(new RegExp('\\s?\\|\\s?', 'g'), newpipe);
+    text2 = text2.replaceAll(new RegExp('\\s?\\|\\s?', 'g'), newpipe);
+
+	// replace unmodified sfns removed earlier
+	text1 = sfns[0] + text1;
+	text1 = text1.replace('ref=}}', 'ref=' + sfns[1] + '}}');
+
+	/**@type {HTMLElement} */(document.getElementById('shortened')).innerHTML = text1;
+    /**@type {HTMLElement} */(document.getElementById('named_ref')).innerHTML = text2;
+}
+
+function onPipeChange() {
+    'use strict';
+	var checkedPipe = getCheckedRadio('pipeformat');
+	var pipeId = checkedPipe.id;
+	changePipes(pipeId);
+	localStorage.setItem("pipefmt", pipeId);
+	updateURL('pipeformat', checkedPipe.value);
+}
+
+function applyLSFormats() {
+	'use strict';
+	var queryParams = new URL(window.location).searchParams;
+
 	var datefmt = localStorage.getItem("datefmt");
-	if (datefmt) {
+	if (datefmt && !queryParams.has('dateformat')) {
 		/**@type {HTMLInputElement} */(document.getElementById(datefmt)).checked = true;
 		changeDates(datefmt);
 	}
+
+	var pipefmt = localStorage.getItem("pipefmt");
+	if (pipefmt && !queryParams.has('pipeformat')) {
+		/**@type {HTMLInputElement} */(document.getElementById(pipefmt)).checked = true;
+		changePipes(pipefmt);
+	}
 }
-applyLSDateFormat();
+applyLSFormats();

--- a/tests/doi_test.py
+++ b/tests/doi_test.py
@@ -42,7 +42,7 @@ def test_doi2():
         '| publisher=University of Chicago Press | volume=40 '
         '| issue=3 | year=2014 | issn=0093-1896 | doi=10.1086/677379 '
         '| pages=272–281 '
-        '| ref={{sfnref | University of Chicago Press | 2014}}'
+        '| ref={{sfnref|University of Chicago Press|2014}}'
         '}}'
     )
     assert citoid_scr('http://www.jstor.org/stable/info/10.1086/677379')[
@@ -50,7 +50,7 @@ def test_doi2():
     ] == (
         '* {{cite journal | title=Books of Critical Interest | journal=Critical '
         'Inquiry | volume=40 | issue=3 | date=2014 | issn=0093-1896 | '
-        'doi=10.1086/677379 | pages=272–281 | ref={{sfnref | Critical Inquiry | '
+        'doi=10.1086/677379 | pages=272–281 | ref={{sfnref|Critical Inquiry|'
         '2014}}}}'
     )
 
@@ -141,7 +141,7 @@ def test_conference_location():
         '| year=2006 '
         '| isbn=1-59593-255-0 '
         '| doi=10.1145/1117278 '
-        '| ref={{sfnref | ACM Press | 2006}}'
+        '| ref={{sfnref|ACM Press|2006}}'
         '}}'
     )
     assert citoid_scr('10.1145/1117278')[1] == (
@@ -262,13 +262,13 @@ def test_doi_with_full_date():  # 36
 
 def test_sfn_extract_year_from_date():
     s, c, r = doi_scr('10.1073/pnas.2015159118')
-    assert s == '{{sfn | Almeida | Viala | Nachtigall | Broe | 2021 | p=}}'
+    assert s == '{{sfn|Almeida|Viala|Nachtigall|Broe|2021|p=}}'
     assert (
         c
         == '* {{cite journal | last=Almeida | first=Diego Dantas | last2=Viala | first2=Vincent Louis | last3=Nachtigall | first3=Pedro Gabriel | last4=Broe | first4=Michael | last5=Gibbs | first5=H. Lisle | last6=Serrano | first6=Solange Maria de Toledo | last7=Moura-da-Silva | first7=Ana Maria | last8=Ho | first8=Paulo Lee | last9=Nishiyama-Jr | first9=Milton Yutaka | last10=Junqueira-de-Azevedo | first10=Inácio L. M. | title=Tracking the recruitment and evolution of snake toxins using the evolutionary context provided by the <i>Bothrops jararaca</i> genome | journal=Proceedings of the National Academy of Sciences | publisher=Proceedings of the National Academy of Sciences | volume=118 | issue=20 | date=2021-05-10 | issn=0027-8424 | doi=10.1073/pnas.2015159118}}'
     )
     s, c, r = citoid_scr('10.1073/pnas.2015159118')
-    assert s == '{{sfn | Almeida | Viala | Nachtigall | Broe | 2021 | p=}}'
+    assert s == '{{sfn|Almeida|Viala|Nachtigall|Broe|2021|p=}}'
     assert c == (
         '* {{cite journal | last=Almeida | first=Diego Dantas | last2=Viala | '
         'first2=Vincent Louis | last3=Nachtigall | first3=Pedro Gabriel | last4=Broe '

--- a/tests/googlebooks_test.py
+++ b/tests/googlebooks_test.py
@@ -40,13 +40,13 @@ def test_gb2():
         'id=U46IzqYLZvAC&pg=PT57#v=onepage&q&f=false'
     )
     assert (
-        '{{sfn '
-        '| Anderson '
-        '| DeBolt '
-        '| Featherstone '
-        '| Gunther '
-        '| 2010 '
-        '| p=57}}'
+        '{{sfn'
+        '|Anderson'
+        '|DeBolt'
+        '|Featherstone'
+        '|Gunther'
+        '|2010'
+        '|p=57}}'
     ) in o[0]
     assert (
         '* {{cite book '
@@ -88,7 +88,7 @@ def test_gb3():
         'Delimiter+is%22&hl=en&sa=X&ei=oNKSUrKeDovItAbO_4CoBA&ved='
         '0CC4Q6AEwAA#v=onepage&q=%22a%20Delimiter%20is%22&f=false'
     )
-    assert '{{sfn | Farrell | 2009 | p=588}}' in o[0]
+    assert '{{sfn|Farrell|2009|p=588}}' in o[0]
     assert (
         '* {{cite book '
         '| last=Farrell '
@@ -112,7 +112,7 @@ def test_gb4():
         'X&ei=hEuYUr_mOsnKswb49oDQCA&ved=0CC4Q6AEwAA#v=onepage&q='
         '%22legal%20translation%20is%22&f=false'
     )
-    assert '{{sfn | Šarčević | 1997 | p=229}}' in o[0]
+    assert '{{sfn|Šarčević|1997|p=229}}' in o[0]
     assert (
         '* {{cite book '
         '| last=Šarčević '

--- a/tests/isbn_oclc_test.py
+++ b/tests/isbn_oclc_test.py
@@ -98,7 +98,7 @@ def test_invalid_oclc():
 
 def test_oclc_with_issn():
     assert oclc_scr('22239204')[1] == (
-        '* {{cite journal | title=73 amateur radio today | publisher=WGE Pub. | publication-place=Hancock, N.H. | year=1990 | issn=1052-2522 | oclc=22239204 | ref={{sfnref | WGE Pub. | 1990}}}}'
+        '* {{cite journal | title=73 amateur radio today | publisher=WGE Pub. | publication-place=Hancock, N.H. | year=1990 | issn=1052-2522 | oclc=22239204 | ref={{sfnref|WGE Pub.|1990}}}}'
     )
 
 

--- a/tests/jstor_test.py
+++ b/tests/jstor_test.py
@@ -8,7 +8,7 @@ def jstor_scr(*args):
 
 def test_1():
     s, c, r = jstor_scr('https://www.jstor.org/stable/30078788')
-    assert s == '{{sfn | Lloyd | 1831 | pp=171–177}}'
+    assert s == '{{sfn|Lloyd|1831|pp=171–177}}'
     assert c[: c.index('| access-date=')] == (
         '* {{cite journal | last=Lloyd | first=Humphrey '
         '| title=On a New Case of Interference of the Rays of Light '

--- a/tests/noorlib_test.py
+++ b/tests/noorlib_test.py
@@ -34,7 +34,7 @@ def test_nl2():
     """The year parameter is not present."""
     i = 'http://www.noorlib.ir/View/fa/Book/BookView/Image/18454'
     o = noorlib_scr(i)
-    assert '{{sfn | کورانی | p=}}' in o[0]
+    assert '{{sfn|کورانی|p=}}' in o[0]
     assert (
         '* {{cite book '
         '| last=کورانی '

--- a/tests/noormags_test.py
+++ b/tests/noormags_test.py
@@ -45,7 +45,7 @@ def test_nm2():
         '692447?sta=%D8%AF%D8%B9%D8%A7%DB%8C%20%D8%A7%D8%A8%D9%88%D8%AD%'
         'D9%85%D8%B2%D9%87%20%D8%AB%D9%85%D8%A7%D9%84%DB%8C'
     )
-    assert '{{sfn | سلیمانی\u200cمیمند | 1389 | pp=103–124}}' in o[0]
+    assert '{{sfn|سلیمانی\u200cمیمند|1389|pp=103–124}}' in o[0]
     assert (
         '* {{cite journal '
         '| last=سلیمانی\u200cمیمند '

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -106,7 +106,8 @@ def test_json_body():
                     b'{'
                     b'"user_input": "https://books.google.com/",'
                     b'"input_type": "url-doi-isbn",'
-                    b'"dateformat": "%#d %B %Y"'
+                    b'"dateformat": "%#d %B %Y",'
+                    b'"pipeformat": " | "'
                     b'}'
                 ),
             },
@@ -133,7 +134,8 @@ def test_html_input():
                     b'{'
                     b'"user_input": {"html": "<HTML>", "url": "<URL>"},'
                     b'"input_type": "html",'
-                    b'"dateformat": "%#d %B %Y"'
+                    b'"dateformat": "%#d %B %Y",'
+                    b'"pipeformat": " | "'
                     b'}'
                 ),
             },

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -49,7 +49,7 @@ def test_dead_url():
         '| archive-url=https://web.archive.org/web/20070429193849id_/http://www.londondevelopmentcentre.org/page.php?s=1&p=2462 '
         '| archive-date=2007-04-29 '
         '| url-status=dead '
-        '| ref={{sfnref | londondevelopmentcentre.org | 2007}} '
+        '| ref={{sfnref|londondevelopmentcentre.org|2007}} '
         '| access-date='
     )
 
@@ -94,7 +94,7 @@ def test_webless_url():
         '| archive-date=2017-01-19 '
         '| url-status=live '
         '| language=fa '
-        '| ref={{sfnref | ایسنا | 2017}} '
+        '| ref={{sfnref|ایسنا|2017}} '
         '| access-date='
     )
 
@@ -105,5 +105,5 @@ def test_archive_today_data():
         '| date=2012-12-11 | '
         'url=http://www.cbsnews.com/stories/2003/11/12/earlyshow/leisure/celebspot/main583274.shtml '
         '| archive-url=https://archive.ph/N3fQ | archive-date=2012-12-11 | '
-        'url-status=dead | ref={{sfnref | cbsnews.com | 2012}} | access-date='
+        'url-status=dead | ref={{sfnref|cbsnews.com|2012}} | access-date='
     )

--- a/tests/urls/test_urls.py
+++ b/tests/urls/test_urls.py
@@ -78,7 +78,7 @@ def test_washingtonpost1():
         'http://www.washingtonpost.com/wp-dyn/content/article/2005/09/02/'
         'AR2005090200822.html'
     )
-    assert '{{sfn | Sachs | 2005}}' in o[0]
+    assert '{{sfn|Sachs|2005}}' in o[0]
     assert (
         '* {{cite web '
         '| last=Sachs '
@@ -98,7 +98,7 @@ def test_huffingtonpost1():
         'http://www.huffingtonpost.ca/annelise-sorg/'
         'blackfish-killer-whale-seaworld_b_3686306.html'
     )
-    assert '{{sfn | Sorg | 2013}}' == o[0]
+    assert '{{sfn|Sorg|2013}}' == o[0]
     assert (
         '* {{cite web '
         '| last=Sorg '
@@ -132,7 +132,7 @@ def test_huffingtonpost2():
         'obamas-climate-change-plan_b_5427656.html '
         '| access-date='
     )
-    assert '{{sfn | Rifkin | 2014}}' == o[0]
+    assert '{{sfn|Rifkin|2014}}' == o[0]
     assert e2 == o[1][:-12]
 
 
@@ -157,7 +157,7 @@ def test_dilytelegraph1():
         'the-barnacles-on-its-back.html '
         '| access-date='
     )
-    assert '{{sfn | Fogle | 2005}}' == o[0]
+    assert '{{sfn|Fogle|2005}}' == o[0]
     assert e2 == o[1][:-12]
 
 
@@ -179,7 +179,7 @@ def test_dilytelegraph2():
         '3313298/Marine-collapse-linked-to-whale-decline.html '
         '| access-date='
     )
-    assert '{{sfn | Highfield | 2003}}' == o[0]
+    assert '{{sfn|Highfield|2003}}' == o[0]
     assert e2 == o[1][:-12]
 
 
@@ -197,7 +197,7 @@ def test_dilytelegraph3():
         '| url=http://www.telegraph.co.uk/news/8323909/The-sperm-whale-works-in-extraordinary-ways.html '
         '| access-date='
     )
-    assert '{{sfn | Whitehead | 2011}}' == o[0]
+    assert '{{sfn|Whitehead|2011}}' == o[0]
     assert e2 == o[1][:-12]
 
 
@@ -207,7 +207,7 @@ def test_dilymail1():
         'http://www.dailymail.co.uk/news/article-2633025/'
         'London-cleric-convicted-NYC-terrorism-trial.html'
     )
-    assert '{{sfn | Malm | Witheridge | Drury | Bates | 2014}}' == o[0]
+    assert '{{sfn|Malm|Witheridge|Drury|Bates|2014}}' == o[0]
     assert (
         '* {{cite web '
         '| last=Malm '
@@ -259,7 +259,7 @@ def test_bbc1():
         '| website=BBC News '
         '| date=2014-06-01 '
         '| url=http://www.bbc.com/news/world-asia-27653361 '
-        '| ref={{sfnref | BBC News | 2014}} '
+        '| ref={{sfnref|BBC News|2014}} '
         '| access-date='
     )
     assert ct == o[1][:-12]
@@ -438,7 +438,7 @@ def test_nyt5():
         '| date=2007-06-13 '
         '| url=http://www.nytimes.com/2007/06/13/world/americas/'
         '13iht-whale.1.6123654.html '
-        '| ref={{sfnref | The New York Times | 2007}} '
+        '| ref={{sfnref|The New York Times|2007}} '
         '| access-date='
     )
     assert ct == o[1][:-12]
@@ -473,7 +473,7 @@ def test_tgdaily1():
         '| date=2014-05-09 '
         '| url=http://www.tgdaily.com/web/'
         '100381-apple-might-buy-beats-for-32-billion '
-        '| ref={{sfnref | TG Daily | 2014}} '
+        '| ref={{sfnref|TG Daily|2014}} '
         '| access-date='
     )
 
@@ -492,7 +492,7 @@ def test_tgdaily2():
         '| date=2013-12-17 '
         '| url=http://www.tgdaily.com/space-features/'
         '82906-sma-reveals-giant-star-cluster-in-the-making '
-        '| ref={{sfnref | TG Daily | 2013}} '
+        '| ref={{sfnref|TG Daily|2013}} '
         '| access-date='
     )
     assert ct == o[1][:-12]
@@ -525,7 +525,7 @@ def test_oth2():
         'articleshow/1163528927.cms?'
     )
     o = urls_scr(i)
-    sfn = '{{sfn | Kashyap | 2001}}'
+    sfn = '{{sfn|Kashyap|2001}}'
     assert sfn in o[0]
 
 
@@ -602,7 +602,7 @@ def test_oth4():
 def test_oth5():
     """Getting the date is tricky here."""
     o = urls_scr('http://www.magiran.com/npview.asp?ID=1410487')
-    assert "{{sfn | ''Magiran'' | 2007}}" in o[0]
+    assert "{{sfn|''Magiran''|2007}}" in o[0]
     assert (
         '* {{cite web '
         # todo: could this be fixed for the new format of magiran?
@@ -614,7 +614,7 @@ def test_oth5():
         '| date=2007-05-22 '
         '| url=https://www.magiran.com/article/1410487 '
         '| language=fa '
-        '| ref={{sfnref | Magiran | 2007}} '
+        '| ref={{sfnref|Magiran|2007}} '
         '| access-date='
     ) == o[1][:-12]
 
@@ -623,9 +623,9 @@ def test_oth6():
     """Detection of website name."""
     o = urls_scr('http://www.farsnews.com/newstext.php?nn=13930418000036')
     assert (
-        '* {{cite web | title=آیت\u200cالله محمدی گیلانی دارفانی را وداع گفت | publisher=Fars News Agency | date=2014-07-09 | url=http://www.farsnews.com/newstext.php?nn=13930418000036 | language=fa | ref={{sfnref | Fars News Agency | 2014}} | access-date='
+        '* {{cite web | title=آیت\u200cالله محمدی گیلانی دارفانی را وداع گفت | publisher=Fars News Agency | date=2014-07-09 | url=http://www.farsnews.com/newstext.php?nn=13930418000036 | language=fa | ref={{sfnref|Fars News Agency|2014}} | access-date='
     ) == o[1][:-12]
-    assert '{{sfn | Fars News Agency | 2014}}' in o[0]
+    assert '{{sfn|Fars News Agency|2014}}' in o[0]
     # Fars news is using 'خبرگزاری فارس' as og:author which is wrong
     # and thats why its name is not italicized in sfn.
 
@@ -709,7 +709,7 @@ def test_oth11():
 def test_oth12():
     # thebulletin.org
     assert urls_scr(
-        'http://thebulletin.org/evidence-shows-iron-dome-not-working7318'
+        'https://thebulletin.org/2014/07/the-evidence-that-shows-iron-dome-is-not-working/'
     )[1][:-12] == (
         '* {{cite web '
         '| last=Postol '
@@ -717,8 +717,7 @@ def test_oth12():
         '| title=The evidence that shows Iron Dome is not working '
         '| website=Bulletin of the Atomic Scientists '
         '| date=2014-07-19 '
-        '| url=http://thebulletin.org/'
-        'evidence-shows-iron-dome-not-working7318 '
+        '| url=https://thebulletin.org/2014/07/the-evidence-that-shows-iron-dome-is-not-working/ '
         '| access-date='
     )
 
@@ -751,7 +750,7 @@ def test_oth14():
         '| date=1999-06-29 '
         '| url=http://www.independent.co.uk/news/business/'
         'the-investment-column-tt-group-1103208.html '
-        '| ref={{sfnref | The Independent | 1999}} '
+        '| ref={{sfnref|The Independent|1999}} '
         '| access-date='
     )
     assert ct == o[1][:-12]
@@ -766,7 +765,7 @@ def test_oth15():
         '| date=2017-01-25 '
         '| url=http://www.isna.ir/news/95110603890/%D8%A8%D8%B1%D8%AC%D8%A7%D9%85-%D8%B4%D8%B1%D8%A7%DB%8C%D8%B7-%D8%A8%DB%8C%D9%86-%D8%A7%D9%84%D9%85%D9%84%D9%84%DB%8C-%D8%A7%DB%8C%D8%B1%D8%A7%D9%86-%D8%B1%D8%A7-%DA%A9%D8%A7%D9%85%D9%84%D8%A7-%D9%85%D8%AA%D8%AD%D9%88%D9%84-%DA%A9%D8%B1%D8%AF '
         '| language=fa '
-        '| ref={{sfnref | ایسنا | 2017}} '
+        '| ref={{sfnref|ایسنا|2017}} '
         '| access-date='
     ) == urls_scr(
         'http://www.isna.ir/news/95110603890/%D8%A8%D8%B1%D8%AC%D8%A7%D9%85-%D8%B4%D8%B1%D8%A7%DB%8C%D8%B7-%D8%A8%DB%8C%D9%86-%D8%A7%D9%84%D9%85%D9%84%D9%84%DB%8C-%D8%A7%DB%8C%D8%B1%D8%A7%D9%86-%D8%B1%D8%A7-%DA%A9%D8%A7%D9%85%D9%84%D8%A7-%D9%85%D8%AA%D8%AD%D9%88%D9%84-%DA%A9%D8%B1%D8%AF'
@@ -777,7 +776,7 @@ def test_invalid_name():
     """Test that URL does not fail with InvalidNameError."""
     url = 'http://www.irinn.ir/fa/news/499654/%D8%A7%D9%86%D8%AA%D8%AE%D8%A7%D8%A8%D8%A7%D8%AA-96-%D8%A8%D9%87-%D8%B1%D9%88%D8%A7%DB%8C%D8%AA-%D8%A2%D9%85%D8%A7%D8%B1'
     assert (
-        '* {{cite web | title=انتخابات 96 به روایت آمار | publisher=پایگاه اطلاع رسانی شبکه خبر صدا و سیمای جمهوری اسلامی ایران | date=2017-05-24 | url=http://www.irinn.ir/fa/news/499654/%D8%A7%D9%86%D8%AA%D8%AE%D8%A7%D8%A8%D8%A7%D8%AA-96-%D8%A8%D9%87-%D8%B1%D9%88%D8%A7%DB%8C%D8%AA-%D8%A2%D9%85%D8%A7%D8%B1 | language=fa | ref={{sfnref | پایگاه اطلاع رسانی شبکه خبر صدا و سیمای جمهوری اسلامی ایران | 2017}} | access-date='
+        '* {{cite web | title=انتخابات 96 به روایت آمار | publisher=پایگاه اطلاع رسانی شبکه خبر صدا و سیمای جمهوری اسلامی ایران | date=2017-05-24 | url=http://www.irinn.ir/fa/news/499654/%D8%A7%D9%86%D8%AA%D8%AE%D8%A7%D8%A8%D8%A7%D8%AA-96-%D8%A8%D9%87-%D8%B1%D9%88%D8%A7%DB%8C%D8%AA-%D8%A2%D9%85%D8%A7%D8%B1 | language=fa | ref={{sfnref|پایگاه اطلاع رسانی شبکه خبر صدا و سیمای جمهوری اسلامی ایران|2017}} | access-date='
     ) == urls_scr(url)[1][:-12]
 
 
@@ -810,7 +809,7 @@ def test_empty_meta_author_content():
         '| website=Al Jazeera '
         '| date=2017-05-29 '
         '| url=http://www.aljazeera.com/news/2017/05/uae-enoc-pays-iran-4-billion-oil-dues-170529171315570.html '
-        '| ref={{sfnref | Al Jazeera | 2017}} '
+        '| ref={{sfnref|Al Jazeera|2017}} '
         '| access-date='
     ) == urls_scr(
         'http://www.aljazeera.com/news/2017/05/'
@@ -870,12 +869,12 @@ def test_abc_author():
 
 def test_indaily():
     assert urls_scr(
-        'https://indaily.com.au/news/2020/03/19/epidemics-expert-contradicts-marshalls-schools-advice/'
+        'https://indaily.com.au/news/2020/03/19/epidemics-expert-contradicts-marshalls-schools-advice'
     )[1][:-12] == (
         '* {{cite web | last=Siebert | first=Bension '
         "| title=Epidemics expert questions Marshall's schools advice "
         '| website=InDaily | date=2020-03-19 '
-        '| url=https://indaily.com.au/news/2020/03/19/epidemics-expert-contradicts-marshalls-schools-advice/ '
+        '| url=https://indaily.com.au/news/2020/03/19/epidemics-expert-contradicts-marshalls-schools-advice '
         '| access-date='
     )
 
@@ -915,7 +914,7 @@ def test_home_site_name():
     assert (
         '* {{cite web | title=Black Convicts | website=University of Tasmania '
         '| url=https://www.utas.edu.au/library/companion_to_tasmanian_history/B/Black%20Convicts.htm '
-        '| ref={{sfnref | University of Tasmania}} | access-date='
+        '| ref={{sfnref|University of Tasmania}} | access-date='
     ) == urls_scr(
         'https://www.utas.edu.au/library/companion_to_tasmanian_history/B/Black%20Convicts.htm'
     )[1][:-12]
@@ -977,7 +976,7 @@ def test_lang_search():
 def test_non_text_content(_0, _1):
     scr = urls_scr('https://example.com/')
     assert scr[1][:-12] == (
-        '* {{cite web | title= | url=https://example.com/ | ref={{sfnref | Anon.}} | access-date='
+        '* {{cite web | title= | url=https://example.com/ | ref={{sfnref|Anon.}} | access-date='
     )
 
 


### PR DESCRIPTION
Citer is currently hardcoded to always have spaces on either side of the pipe delimiter `|` between cite template parameters:

`{{cite book | last= | first= | date=}}`

This is inconsistent with the apparently preferred style shown on the [template help pages](https://en.wikipedia.org/wiki/Template:Cite_book), as well as the "insert template" option in the page editor, which use an asymmetrical style like:

`{{cite book |last= |first= |date=}}`

And those who are efficiency-minded may wish to forego spaces between params entirely (or just to match exists cites on the page for consistency):

`{{cite book|last=|first=|date=}}`

This PR adds a "Pipe spacing" selection, functioning the same as the "Date format" selector already present. However, regardless of the option selected, it does newly enforce compact/no spaces on the specific `{{sfn|Name|2024}}` templates, again in reflection of the [template help page](https://en.wikipedia.org/wiki/Template:Sfn) usage, and because there is much less need for spaces to improve readability with so few parameters.